### PR TITLE
Add support for parsing operator expressions in `op`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,5 +9,5 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 LinearAlgebra = "1.10"
-Random = "1.11.0"
+Random = "1.10"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumOperatorDefinitions"
 uuid = "826dd319-6fd5-459a-a990-3a4f214664bf"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,9 @@ version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 LinearAlgebra = "1.10"
+Random = "1.11.0"
 julia = "1.10"

--- a/src/sitetypes/electron.jl
+++ b/src/sitetypes/electron.jl
@@ -238,8 +238,8 @@ function Base.AbstractArray(::OpName"Sˣ", st::Tuple{SiteType"Electron"})
   return AbstractArray(OpName("Sx"), st)
 end
 
-function Base.AbstractArray(::OpName"S+", ::Tuple{SiteType"Electron"})
-  # cat(falses(1, 1), Matrix(OpName("S+")), falses(1, 1); dims=(1, 2))
+function Base.AbstractArray(::OpName"S⁺", ::Tuple{SiteType"Electron"})
+  # cat(falses(1, 1), Matrix(OpName("S⁺")), falses(1, 1); dims=(1, 2))
   return [
     0.0 0.0 0.0 0.0
     0.0 0.0 1.0 0.0
@@ -247,19 +247,15 @@ function Base.AbstractArray(::OpName"S+", ::Tuple{SiteType"Electron"})
     0.0 0.0 0.0 0.0
   ]
 end
-
-function Base.AbstractArray(::OpName"S⁺", st::Tuple{SiteType"Electron"})
-  return AbstractArray(OpName("S+"), st)
-end
 function Base.AbstractArray(::OpName"Sp", st::Tuple{SiteType"Electron"})
-  return AbstractArray(OpName("S+"), st)
+  return AbstractArray(OpName("S⁺"), st)
 end
 function Base.AbstractArray(::OpName"Splus", st::Tuple{SiteType"Electron"})
-  return AbstractArray(OpName("S+"), st)
+  return AbstractArray(OpName("S⁺"), st)
 end
 
-function Base.AbstractArray(::OpName"S-", ::Tuple{SiteType"Electron"})
-  # cat(falses(1, 1), Matrix(OpName("S-")), falses(1, 1); dims=(1, 2))
+function Base.AbstractArray(::OpName"S⁻", ::Tuple{SiteType"Electron"})
+  # cat(falses(1, 1), Matrix(OpName("S⁻")), falses(1, 1); dims=(1, 2))
   return [
     0.0 0.0 0.0 0.0
     0.0 0.0 0.0 0.0
@@ -267,15 +263,11 @@ function Base.AbstractArray(::OpName"S-", ::Tuple{SiteType"Electron"})
     0.0 0.0 0.0 0.0
   ]
 end
-
-function Base.AbstractArray(::OpName"S⁻", st::Tuple{SiteType"Electron"})
-  return AbstractArray(OpName("S-"), st)
-end
 function Base.AbstractArray(::OpName"Sm", st::Tuple{SiteType"Electron"})
-  return AbstractArray(OpName("S-"), st)
+  return AbstractArray(OpName("S⁻"), st)
 end
 function Base.AbstractArray(::OpName"Sminus", st::Tuple{SiteType"Electron"})
-  return AbstractArray(OpName("S-"), st)
+  return AbstractArray(OpName("S⁻"), st)
 end
 
 @op_alias "a↑" "Aup"

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -119,14 +119,13 @@ const elts = (real_elts..., complex_elts...)
     end
   end
   @testset "Parsing" begin
-    # TODO: Should this be called in the `OpName`/`op` constructor?
     @test Matrix(opexpr("X * Y")) == op("X") * op("Y")
-    @test Matrix(opexpr("X * Y + Z")) == op("X") * op("Y") + op("Z")
-    @test Matrix(opexpr("X * Y + 2 * Z")) == op("X") * op("Y") + 2 * op("Z")
-    @test Matrix(opexpr("exp(im * (X * Y + 2 * Z))")) ==
-      exp(im * (op("X") * op("Y") + 2 * op("Z")))
-    @test Matrix(opexpr("exp(im * (X ⊗ Y + Z ⊗ Z))")) ==
+    @test op("X * Y") == op("X") * op("Y")
+    @test op("X * Y + Z") == op("X") * op("Y") + op("Z")
+    @test op("X * Y + 2 * Z") == op("X") * op("Y") + 2 * op("Z")
+    @test op("exp(im * (X * Y + 2 * Z))") == exp(im * (op("X") * op("Y") + 2 * op("Z")))
+    @test op("exp(im * (X ⊗ Y + Z ⊗ Z))") ==
       exp(im * (kron(op("X"), op("Y")) + kron(op("Z"), op("Z"))))
-    @test Matrix(opexpr("Ry{θ=π/2}")) == op("Ry"; θ=π / 2)
+    @test op("Ry{θ=π/2}") == op("Ry"; θ=π / 2)
   end
 end


### PR DESCRIPTION
For example:
```julia
julia> using QuantumOperatorDefinitions

julia> op("X + 2Z")
2×2 Matrix{Float64}:
 2.0   1.0
 1.0  -2.0

julia> op("exp(im * (X + 2Z))")
2×2 Matrix{ComplexF64}:
   -0.617273+0.70369im   -2.77556e-17+0.351845im
 5.55112e-17+0.351845im     -0.617273-0.70369im
```
Closes #11 .