### PR TITLE
Allow custom axes when constructing operators, SymmetrySectors.jl and ITensorBase.jl extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumOperatorDefinitions"
 uuid = "826dd319-6fd5-459a-a990-3a4f214664bf"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -8,15 +8,24 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [weakdeps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
+LabelledNumbers = "f856a3a6-4152-4ec4-b2a7-02c1a55d7993"
 ITensorBase = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
 NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
+SymmetrySectors = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 
 [extensions]
 QuantumOperatorDefinitionsITensorBaseExt = ["ITensorBase", "NamedDimsArrays"]
+QuantumOperatorDefinitionsSymmetrySectorsExt = ["BlockArrays", "GradedUnitRanges", "LabelledNumbers", "SymmetrySectors"]
 
 [compat]
+BlockArrays = "1.3.0"
+GradedUnitRanges = "0.1.2"
 ITensorBase = "0.1.10"
+LabelledNumbers = "0.1.0"
 LinearAlgebra = "1.10"
 NamedDimsArrays = "0.4.0"
 Random = "1.10"
+SymmetrySectors = "0.1.3"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,14 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [weakdeps]
 ITensorBase = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
+NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 
 [extensions]
-QuantumOperatorDefinitionsITensorBaseExt = "ITensorBase"
+QuantumOperatorDefinitionsITensorBaseExt = ["ITensorBase", "NamedDimsArrays"]
 
 [compat]
 ITensorBase = "0.1.10"
 LinearAlgebra = "1.10"
+NamedDimsArrays = "0.4.0"
 Random = "1.10"
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ julia> Pkg.add("QuantumOperatorDefinitions")
 
 ````julia
 using QuantumOperatorDefinitions: OpName, SiteType, StateName, ⊗, controlled, op, state
-using LinearAlgebra: Diagonal
 using SparseArrays: SparseMatrixCSC, SparseVector
 using Test: @test
 
@@ -63,8 +62,6 @@ using Test: @test
 @test op("X") == [0 1; 1 0]
 @test op("Y") == [0 -im; im 0]
 @test op("Z") == [1 0; 0 -1]
-
-@test op("Z") isa Diagonal
 
 @test op(Float32, "X") == [0 1; 1 0]
 @test eltype(op(Float32, "X")) === Float32

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -38,7 +38,6 @@ julia> Pkg.add("QuantumOperatorDefinitions")
 # ## Examples
 
 using QuantumOperatorDefinitions: OpName, SiteType, StateName, ⊗, controlled, op, state
-using LinearAlgebra: Diagonal
 using SparseArrays: SparseMatrixCSC, SparseVector
 using Test: @test
 
@@ -68,8 +67,6 @@ using Test: @test
 @test op("X") == [0 1; 1 0]
 @test op("Y") == [0 -im; im 0]
 @test op("Z") == [1 0; 0 -1]
-
-@test op("Z") isa Diagonal
 
 @test op(Float32, "X") == [0 1; 1 0]
 @test eltype(op(Float32, "X")) === Float32

--- a/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
+++ b/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
@@ -1,6 +1,6 @@
 module QuantumOperatorDefinitionsITensorBaseExt
 
-using ITensorBase: ITensor, Index, dag, gettag, prime
+using ITensorBase: ITensorBase, ITensor, Index, dag, gettag, prime
 using NamedDimsArrays: dename
 using QuantumOperatorDefinitions:
   QuantumOperatorDefinitions, OpName, SiteType, StateName, has_fermion_string
@@ -13,6 +13,10 @@ function QuantumOperatorDefinitions.SiteType(r::Index)
   return SiteType(
     gettag(r, "sitetype", "Qudit"); dim=Int.(length(r)), range=only(axes(dename(r)))
   )
+end
+
+function ITensorBase.Index(t::SiteType; kwargs...)
+  return Index(AbstractUnitRange(t); kwargs...)
 end
 
 function QuantumOperatorDefinitions.has_fermion_string(n::String, r::Index)

--- a/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
+++ b/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
@@ -1,9 +1,15 @@
 module QuantumOperatorDefinitionsITensorBaseExt
 
-using ITensorBase: ITensorBase, ITensor, Index, dag, gettag, prime
+using ITensorBase: ITensorBase, ITensor, Index, dag, gettag, prime, settag
 using NamedDimsArrays: dename
 using QuantumOperatorDefinitions:
-  QuantumOperatorDefinitions, @OpName_str, OpName, SiteType, StateName, has_fermion_string
+  QuantumOperatorDefinitions,
+  @OpName_str,
+  OpName,
+  SiteType,
+  StateName,
+  has_fermion_string,
+  name
 
 function QuantumOperatorDefinitions.SiteType(r::Index)
   # We pass the axis of the (unnamed) Index because
@@ -14,6 +20,10 @@ function QuantumOperatorDefinitions.SiteType(r::Index)
   return SiteType(
     gettag(r, "sitetype", "Qudit"); dim=Int.(length(r)), range=only(axes(dename(r)))
   )
+end
+
+function (rangetype::Type{<:Index})(t::SiteType)
+  return settag(rangetype(AbstractUnitRange(t)), "sitetype", String(name(t)))
 end
 
 # TODO: Define in terms of `OpName` directly, and define a generic
@@ -28,5 +38,21 @@ end
 ## function Base.axes(::OpName"SWAP", domain::Tuple{Vararg{Index}})
 ##   return (prime.(reverse(domain))..., dag.(domain)...)
 ## end
+
+# Fix ambiguity error with generic `AbstractArray` version.
+function ITensorBase.ITensor(n::Union{OpName,StateName}, domain::Index...)
+  return ITensor(n, domain)
+end
+# Fix ambiguity error with generic `AbstractArray` version.
+function ITensorBase.ITensor(n::Union{OpName,StateName}, domain::Tuple{Vararg{Index}})
+  return ITensor(AbstractArray(n, domain), axes(n, domain))
+end
+function (arrtype::Type{<:AbstractArray})(
+  n::Union{OpName,StateName}, domain::Tuple{Vararg{Index}}
+)
+  # Convert to `SiteType` in case the Index specifies a `"sitetype"` tag.
+  # TODO: Try to build this into the generic codepath.
+  return ITensor(arrtype(n, SiteType.(domain)), axes(n, domain))
+end
 
 end

--- a/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
+++ b/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
@@ -3,7 +3,7 @@ module QuantumOperatorDefinitionsITensorBaseExt
 using ITensorBase: ITensorBase, ITensor, Index, dag, gettag, prime
 using NamedDimsArrays: dename
 using QuantumOperatorDefinitions:
-  QuantumOperatorDefinitions, OpName, SiteType, StateName, has_fermion_string
+  QuantumOperatorDefinitions, @OpName_str, OpName, SiteType, StateName, has_fermion_string
 
 function QuantumOperatorDefinitions.SiteType(r::Index)
   # We pass the axis of the (unnamed) Index because
@@ -25,5 +25,8 @@ end
 function Base.axes(::OpName, domain::Tuple{Vararg{Index}})
   return (prime.(domain)..., dag.(domain)...)
 end
+## function Base.axes(::OpName"SWAP", domain::Tuple{Vararg{Index}})
+##   return (prime.(reverse(domain))..., dag.(domain)...)
+## end
 
 end

--- a/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
+++ b/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
@@ -1,11 +1,18 @@
 module QuantumOperatorDefinitionsITensorBaseExt
 
 using ITensorBase: ITensor, Index, dag, gettag, prime
+using NamedDimsArrays: dename
 using QuantumOperatorDefinitions:
   QuantumOperatorDefinitions, OpName, SiteType, StateName, has_fermion_string
 
 function QuantumOperatorDefinitions.SiteType(r::Index)
-  return SiteType(gettag(r, "sitetype", "Qudit"); dim=Int(length(r)))
+  # We pass the axis of the (unnamed) Index because
+  # the Index may have originated from a slice, in which
+  # case the start may not be 1 (and it may not even
+  # be a unit range).
+  return SiteType(
+    gettag(r, "sitetype", "Qudit"); dim=Int.(length(r)), range=only(axes(dename(r)))
+  )
 end
 
 function QuantumOperatorDefinitions.has_fermion_string(n::String, r::Index)
@@ -14,6 +21,7 @@ end
 
 function Base.AbstractArray(n::OpName, r::Index)
   # TODO: Define this with mapped dimnames.
+  # Generalize beyond prime levels with codomain and domain indices.
   return ITensor(AbstractArray(n, SiteType(r)), (prime(r), dag(r)))
 end
 

--- a/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
+++ b/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
@@ -8,29 +8,18 @@ using QuantumOperatorDefinitions:
 function QuantumOperatorDefinitions.SiteType(r::Index)
   # We pass the axis of the (unnamed) Index because
   # the Index may have originated from a slice, in which
-  # case the start may not be 1 (and it may not even
+  # case the start may not be 1 (for NonContiguousIndex,
+  # which we need to add support for, it may not even
   # be a unit range).
   return SiteType(
     gettag(r, "sitetype", "Qudit"); dim=Int.(length(r)), range=only(axes(dename(r)))
   )
 end
 
-function ITensorBase.Index(t::SiteType; kwargs...)
-  return Index(AbstractUnitRange(t); kwargs...)
-end
-
+# TODO: Define in terms of `OpName` directly, and define a generic
+# forwarding method `has_fermion_string(n::String, t) = has_fermion_string(OpName(n), t)`.
 function QuantumOperatorDefinitions.has_fermion_string(n::String, r::Index)
   return has_fermion_string(OpName(n), SiteType(r))
-end
-
-function Base.AbstractArray(n::OpName, r::Index)
-  # TODO: Define this with mapped dimnames.
-  # Generalize beyond prime levels with codomain and domain indices.
-  return ITensor(AbstractArray(n, SiteType(r)), (prime(r), dag(r)))
-end
-
-function Base.AbstractArray(n::StateName, r::Index)
-  return ITensor(AbstractArray(n, SiteType(r)), (r,))
 end
 
 end

--- a/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
+++ b/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
@@ -22,4 +22,8 @@ function QuantumOperatorDefinitions.has_fermion_string(n::String, r::Index)
   return has_fermion_string(OpName(n), SiteType(r))
 end
 
+function Base.axes(::OpName, domain::Tuple{Vararg{Index}})
+  return (prime.(domain)..., dag.(domain)...)
+end
+
 end

--- a/ext/QuantumOperatorDefinitionsSymmetrySectorsExt/QuantumOperatorDefinitionsSymmetrySectorsExt.jl
+++ b/ext/QuantumOperatorDefinitionsSymmetrySectorsExt/QuantumOperatorDefinitionsSymmetrySectorsExt.jl
@@ -1,11 +1,21 @@
 module QuantumOperatorDefinitionsSymmetrySectorsExt
 
 using BlockArrays: blocklasts, blocklengths
-using GradedUnitRanges: GradedOneTo, gradedrange
+using GradedUnitRanges: AbstractGradedUnitRange, GradedOneTo, gradedrange
 using LabelledNumbers: label, labelled, unlabel
 using QuantumOperatorDefinitions:
-  QuantumOperatorDefinitions, @SiteType_str, @GradingType_str, SiteType, GradingType, name
-using SymmetrySectors: ×, SectorProduct, U1, Z
+  QuantumOperatorDefinitions,
+  @SiteType_str,
+  @GradingType_str,
+  SiteType,
+  GradingType,
+  OpName,
+  name
+using SymmetrySectors: ×, dual, SectorProduct, U1, Z
+
+function Base.axes(::OpName, domain::Tuple{Vararg{AbstractGradedUnitRange}})
+  return (domain..., dual.(domain)...)
+end
 
 sortedunion(a, b) = sort(union(a, b))
 function QuantumOperatorDefinitions.combine_axes(a1::GradedOneTo, a2::GradedOneTo)

--- a/ext/QuantumOperatorDefinitionsSymmetrySectorsExt/QuantumOperatorDefinitionsSymmetrySectorsExt.jl
+++ b/ext/QuantumOperatorDefinitionsSymmetrySectorsExt/QuantumOperatorDefinitionsSymmetrySectorsExt.jl
@@ -1,0 +1,86 @@
+module QuantumOperatorDefinitionsSymmetrySectorsExt
+
+using BlockArrays: blocklasts, blocklengths
+using GradedUnitRanges: GradedOneTo, gradedrange
+using LabelledNumbers: label, labelled, unlabel
+using QuantumOperatorDefinitions:
+  QuantumOperatorDefinitions, @SiteType_str, @SymmetryType_str, SiteType, SymmetryType, name
+using SymmetrySectors: ×, SectorProduct, U1, Z
+
+sortedunion(a, b) = sort(union(a, b))
+function QuantumOperatorDefinitions.combine_axes(a1::GradedOneTo, a2::GradedOneTo)
+  return gradedrange(
+    map(blocklengths(a1), blocklengths(a2)) do s1, s2
+      l1 = unlabel(s1)
+      l2 = unlabel(s2)
+      @assert l1 == l2
+      labelled(l1, label(s1) × label(s2))
+    end,
+  )
+end
+QuantumOperatorDefinitions.combine_axes(a::GradedOneTo, b::Base.OneTo) = a
+QuantumOperatorDefinitions.combine_axes(a::Base.OneTo, b::GradedOneTo) = b
+
+function Base.AbstractUnitRange(::SymmetryType"N", t::SiteType)
+  return gradedrange(map(i -> SectorProduct((; N=U1(i - 1))) => 1, 1:length(t)))
+end
+function Base.AbstractUnitRange(::SymmetryType"Sz", t::SiteType)
+  return gradedrange(map(i -> SectorProduct((; Sz=U1(i - 1))) => 1, 1:length(t)))
+end
+function Base.AbstractUnitRange(::SymmetryType"Sz↑", t::SiteType)
+  return AbstractUnitRange(SymmetryType"Sz"(), t)
+end
+function Base.AbstractUnitRange(::SymmetryType"Sz↓", t::SiteType)
+  return gradedrange(map(i -> SectorProduct((; Sz=U1(-(i - 1)))) => 1, 1:length(t)))
+end
+
+function sector(symmetrytype::SymmetryType, sec)
+  sectorname = Symbol(get(symmetrytype, :name, name(symmetrytype)))
+  return SectorProduct(NamedTuple{(sectorname,)}((sec,)))
+end
+
+function Base.AbstractUnitRange(s::SymmetryType"Nf", t::SiteType"Fermion")
+  return gradedrange([sector(s, U1(0)) => 1, sector(s, U1(1)) => 1])
+end
+# TODO: Write in terms of `SymmetryType"Nf"` definition.
+function Base.AbstractUnitRange(s::SymmetryType"NfParity", t::SiteType"Fermion")
+  return gradedrange([sector(s, Z{2}(0)) => 1, sector(s, Z{2}(1)) => 1])
+end
+function Base.AbstractUnitRange(s::SymmetryType"Sz", t::SiteType"Fermion")
+  return gradedrange([sector(s, U1(0)) => 1, sector(s, U1(1)) => 1])
+end
+function Base.AbstractUnitRange(s::SymmetryType"Sz↑", t::SiteType"Fermion")
+  return gradedrange([sector(s, U1(0)) => 1, sector(s, U1(1)) => 1])
+end
+function Base.AbstractUnitRange(s::SymmetryType"Sz↓", t::SiteType"Fermion")
+  return gradedrange([sector(s, U1(0)) => 1, sector(s, U1(-1)) => 1])
+end
+
+# TODO: Write in terms of `SiteType"Fermion"` definitions.
+function Base.AbstractUnitRange(s::SymmetryType"Nf", t::SiteType"Electron")
+  return gradedrange([
+    sector(s, U1(0)) => 1,
+    sector(s, U1(1)) => 1,
+    sector(s, U1(1)) => 1,
+    sector(s, U1(2)) => 1,
+  ])
+end
+# TODO: Write in terms of `SymmetryType"Nf"` definition.
+function Base.AbstractUnitRange(s::SymmetryType"NfParity", t::SiteType"Electron")
+  return gradedrange([
+    sector(s, Z{2}(0)) => 1,
+    sector(s, Z{2}(1)) => 1,
+    sector(s, Z{2}(1)) => 1,
+    sector(s, Z{2}(0)) => 1,
+  ])
+end
+function Base.AbstractUnitRange(s::SymmetryType"Sz", t::SiteType"Electron")
+  return gradedrange([
+    sector(s, U1(0)) => 1,
+    sector(s, U1(1)) => 1,
+    sector(s, U1(-1)) => 1,
+    sector(s, U1(0)) => 1,
+  ])
+end
+
+end

--- a/ext/QuantumOperatorDefinitionsSymmetrySectorsExt/QuantumOperatorDefinitionsSymmetrySectorsExt.jl
+++ b/ext/QuantumOperatorDefinitionsSymmetrySectorsExt/QuantumOperatorDefinitionsSymmetrySectorsExt.jl
@@ -4,7 +4,7 @@ using BlockArrays: blocklasts, blocklengths
 using GradedUnitRanges: GradedOneTo, gradedrange
 using LabelledNumbers: label, labelled, unlabel
 using QuantumOperatorDefinitions:
-  QuantumOperatorDefinitions, @SiteType_str, @SymmetryType_str, SiteType, SymmetryType, name
+  QuantumOperatorDefinitions, @SiteType_str, @GradingType_str, SiteType, GradingType, name
 using SymmetrySectors: ×, SectorProduct, U1, Z
 
 sortedunion(a, b) = sort(union(a, b))
@@ -21,43 +21,43 @@ end
 QuantumOperatorDefinitions.combine_axes(a::GradedOneTo, b::Base.OneTo) = a
 QuantumOperatorDefinitions.combine_axes(a::Base.OneTo, b::GradedOneTo) = b
 
-function Base.AbstractUnitRange(::SymmetryType"N", t::SiteType)
+function Base.AbstractUnitRange(::GradingType"N", t::SiteType)
   return gradedrange(map(i -> SectorProduct((; N=U1(i - 1))) => 1, 1:length(t)))
 end
-function Base.AbstractUnitRange(::SymmetryType"Sz", t::SiteType)
+function Base.AbstractUnitRange(::GradingType"Sz", t::SiteType)
   return gradedrange(map(i -> SectorProduct((; Sz=U1(i - 1))) => 1, 1:length(t)))
 end
-function Base.AbstractUnitRange(::SymmetryType"Sz↑", t::SiteType)
-  return AbstractUnitRange(SymmetryType"Sz"(), t)
+function Base.AbstractUnitRange(::GradingType"Sz↑", t::SiteType)
+  return AbstractUnitRange(GradingType"Sz"(), t)
 end
-function Base.AbstractUnitRange(::SymmetryType"Sz↓", t::SiteType)
+function Base.AbstractUnitRange(::GradingType"Sz↓", t::SiteType)
   return gradedrange(map(i -> SectorProduct((; Sz=U1(-(i - 1)))) => 1, 1:length(t)))
 end
 
-function sector(symmetrytype::SymmetryType, sec)
-  sectorname = Symbol(get(symmetrytype, :name, name(symmetrytype)))
+function sector(gradingtype::GradingType, sec)
+  sectorname = Symbol(get(gradingtype, :name, name(gradingtype)))
   return SectorProduct(NamedTuple{(sectorname,)}((sec,)))
 end
 
-function Base.AbstractUnitRange(s::SymmetryType"Nf", t::SiteType"Fermion")
+function Base.AbstractUnitRange(s::GradingType"Nf", t::SiteType"Fermion")
   return gradedrange([sector(s, U1(0)) => 1, sector(s, U1(1)) => 1])
 end
-# TODO: Write in terms of `SymmetryType"Nf"` definition.
-function Base.AbstractUnitRange(s::SymmetryType"NfParity", t::SiteType"Fermion")
+# TODO: Write in terms of `GradingType"Nf"` definition.
+function Base.AbstractUnitRange(s::GradingType"NfParity", t::SiteType"Fermion")
   return gradedrange([sector(s, Z{2}(0)) => 1, sector(s, Z{2}(1)) => 1])
 end
-function Base.AbstractUnitRange(s::SymmetryType"Sz", t::SiteType"Fermion")
+function Base.AbstractUnitRange(s::GradingType"Sz", t::SiteType"Fermion")
   return gradedrange([sector(s, U1(0)) => 1, sector(s, U1(1)) => 1])
 end
-function Base.AbstractUnitRange(s::SymmetryType"Sz↑", t::SiteType"Fermion")
+function Base.AbstractUnitRange(s::GradingType"Sz↑", t::SiteType"Fermion")
   return gradedrange([sector(s, U1(0)) => 1, sector(s, U1(1)) => 1])
 end
-function Base.AbstractUnitRange(s::SymmetryType"Sz↓", t::SiteType"Fermion")
+function Base.AbstractUnitRange(s::GradingType"Sz↓", t::SiteType"Fermion")
   return gradedrange([sector(s, U1(0)) => 1, sector(s, U1(-1)) => 1])
 end
 
 # TODO: Write in terms of `SiteType"Fermion"` definitions.
-function Base.AbstractUnitRange(s::SymmetryType"Nf", t::SiteType"Electron")
+function Base.AbstractUnitRange(s::GradingType"Nf", t::SiteType"Electron")
   return gradedrange([
     sector(s, U1(0)) => 1,
     sector(s, U1(1)) => 1,
@@ -65,8 +65,8 @@ function Base.AbstractUnitRange(s::SymmetryType"Nf", t::SiteType"Electron")
     sector(s, U1(2)) => 1,
   ])
 end
-# TODO: Write in terms of `SymmetryType"Nf"` definition.
-function Base.AbstractUnitRange(s::SymmetryType"NfParity", t::SiteType"Electron")
+# TODO: Write in terms of `GradingType"Nf"` definition.
+function Base.AbstractUnitRange(s::GradingType"NfParity", t::SiteType"Electron")
   return gradedrange([
     sector(s, Z{2}(0)) => 1,
     sector(s, Z{2}(1)) => 1,
@@ -74,7 +74,7 @@ function Base.AbstractUnitRange(s::SymmetryType"NfParity", t::SiteType"Electron"
     sector(s, Z{2}(0)) => 1,
   ])
 end
-function Base.AbstractUnitRange(s::SymmetryType"Sz", t::SiteType"Electron")
+function Base.AbstractUnitRange(s::GradingType"Sz", t::SiteType"Electron")
   return gradedrange([
     sector(s, U1(0)) => 1,
     sector(s, U1(1)) => 1,

--- a/src/op.jl
+++ b/src/op.jl
@@ -98,7 +98,7 @@ function array(a::AbstractArray, ax::Tuple{Vararg{AbstractUnitRange}})
   return a[ax...]
 end
 
-function state_or_op_axes(::OpName, domain::Tuple{Vararg{AbstractUnitRange}})
+function Base.axes(::OpName, domain::Tuple{Vararg{AbstractUnitRange}})
   return (domain..., domain...)
 end
 
@@ -108,7 +108,7 @@ function state_or_op_convert(
   domain::Tuple{Vararg{AbstractUnitRange}},
   a::AbstractArray,
 )
-  ax = state_or_op_axes(n, domain)
+  ax = axes(n, domain)
   a′ = reshape(a, length.(ax))
   a′′ = array(a′, ax)
   return convert(arrtype, a′′)

--- a/src/op.jl
+++ b/src/op.jl
@@ -506,7 +506,7 @@ function (n::OpName"Controlled")(domain...)
   # Number of control sites.
   nc = get(params(n), :ncontrol, length(domain) - nt)
   @assert length(domain) == nc + nt
-  d_control = prod(to_dim.(domain)) - prod(domain[(nc + 1):end])
+  d_control = prod(to_dim.(domain)) - prod(to_dim.(domain[(nc + 1):end]))
   return cat(I(d_control), n.arg(domain[(nc + 1):end]...); dims=(1, 2))
 end
 @op_alias "CNOT" "Controlled" arg = OpName"X"()

--- a/src/sitetype.jl
+++ b/src/sitetype.jl
@@ -4,33 +4,77 @@ struct SiteType{T,Params}
     return new{N,typeof(params)}(params)
   end
 end
-value(::SiteType{T}) where {T} = T
+name(::SiteType{T}) where {T} = T
 params(t::SiteType) = getfield(t, :params)
 Base.getproperty(t::SiteType, name::Symbol) = getfield(params(t), name)
 Base.get(t::SiteType, name::Symbol, default) = get(params(t), name, default)
-
+Base.haskey(t::SiteType, name::Symbol) = haskey(params(t), name)
 SiteType{N}(; kwargs...) where {N} = SiteType{N}((; kwargs...))
-
 SiteType(s::AbstractString; kwargs...) = SiteType{Symbol(s)}(; kwargs...)
 SiteType(i::Integer; kwargs...) = SiteType{Symbol(i)}(; kwargs...)
 macro SiteType_str(s)
-  return SiteType{Symbol(s)}
+  return :(SiteType{$(Expr(:quote, Symbol(s)))})
 end
 
 alias(t::SiteType) = t
 alias(i::Integer) = i
 
+# Like `Base.Broadcast.axistype` (https://github.com/JuliaLang/julia/blob/v1.11.3/base/broadcast.jl#L536-L538)
+# and `BlockArrays.combine_blockaxes` (https://github.com/JuliaArrays/BlockArrays.jl/blob/v1.3.0/src/blockbroadcast.jl#L37-L38).
+combine_axes(a::T, b::T) where {T} = a
+combine_axes(a::Base.OneTo, b::Base.OneTo) = Base.OneTo{Int}(a)
+function combine_axes(a, b)
+  return UnitRange{Int}(a)
+end
+combine_axes(a) = a
+combine_axes(a, b, rest...) = combine_axes(combine_axes(a, b), rest...)
+
+struct SymmetryType{T,Params}
+  params::Params
+  function SymmetryType{N}(params::NamedTuple) where {N}
+    return new{N,typeof(params)}(params)
+  end
+end
+name(::SymmetryType{T}) where {T} = T
+params(t::SymmetryType) = getfield(t, :params)
+Base.getproperty(t::SymmetryType, name::Symbol) = getfield(params(t), name)
+Base.get(t::SymmetryType, name::Symbol, default) = get(params(t), name, default)
+Base.haskey(t::SymmetryType, name::Symbol) = haskey(params(t), name)
+SymmetryType{N}(; kwargs...) where {N} = SymmetryType{N}((; kwargs...))
+SymmetryType(s::AbstractString; kwargs...) = SymmetryType{Symbol(s)}(; kwargs...)
+function SymmetryType(s::Pair{<:AbstractString,<:AbstractString}; kwargs...)
+  return SymmetryType(first(s); kwargs..., name=last(s))
+end
+function SymmetryType(s::Pair{<:AbstractString,<:NamedTuple}; kwargs...)
+  return SymmetryType(first(s); kwargs..., last(s)...)
+end
+macro SymmetryType_str(s)
+  return :(SymmetryType{$(Expr(:quote, Symbol(s)))})
+end
+
+function Base.AbstractUnitRange(symmetry::SymmetryType, t::SiteType)
+  return error("Not implemented.")
+end
+function Base.AbstractUnitRange(symmetry::SymmetryType"Trivial", t::SiteType)
+  return Base.OneTo(length(t))
+end
+
 function Base.length(t::SiteType)
   t′ = alias(t)
   if t == t′
-    return t.length
+    return t.dim
   end
   return length(t′)
 end
 function Base.AbstractUnitRange(t::SiteType)
   # This logic allows specifying a range with extra properties,
   # like ones with symmetry sectors.
-  return get(t, :range, Base.OneTo(length(t)))
+  haskey(t, :range) && return t.range
+  if haskey(t, :symmetries)
+    rs = map(symmetry -> AbstractUnitRange(SymmetryType(symmetry), t), t.symmetries)
+    return combine_axes(Base.OneTo(length(t)), rs...)
+  end
+  return Base.OneTo(length(t))
 end
 Base.size(t::SiteType) = (length(t),)
 Base.size(t::SiteType, dim::Integer) = size(t)[dim]

--- a/src/sitetype.jl
+++ b/src/sitetype.jl
@@ -29,33 +29,33 @@ end
 combine_axes(a) = a
 combine_axes(a, b, rest...) = combine_axes(combine_axes(a, b), rest...)
 
-struct SymmetryType{T,Params}
+struct GradingType{T,Params}
   params::Params
-  function SymmetryType{N}(params::NamedTuple) where {N}
+  function GradingType{N}(params::NamedTuple) where {N}
     return new{N,typeof(params)}(params)
   end
 end
-name(::SymmetryType{T}) where {T} = T
-params(t::SymmetryType) = getfield(t, :params)
-Base.getproperty(t::SymmetryType, name::Symbol) = getfield(params(t), name)
-Base.get(t::SymmetryType, name::Symbol, default) = get(params(t), name, default)
-Base.haskey(t::SymmetryType, name::Symbol) = haskey(params(t), name)
-SymmetryType{N}(; kwargs...) where {N} = SymmetryType{N}((; kwargs...))
-SymmetryType(s::AbstractString; kwargs...) = SymmetryType{Symbol(s)}(; kwargs...)
-function SymmetryType(s::Pair{<:AbstractString,<:AbstractString}; kwargs...)
-  return SymmetryType(first(s); kwargs..., name=last(s))
+name(::GradingType{T}) where {T} = T
+params(t::GradingType) = getfield(t, :params)
+Base.getproperty(t::GradingType, name::Symbol) = getfield(params(t), name)
+Base.get(t::GradingType, name::Symbol, default) = get(params(t), name, default)
+Base.haskey(t::GradingType, name::Symbol) = haskey(params(t), name)
+GradingType{N}(; kwargs...) where {N} = GradingType{N}((; kwargs...))
+GradingType(s::AbstractString; kwargs...) = GradingType{Symbol(s)}(; kwargs...)
+function GradingType(s::Pair{<:AbstractString,<:AbstractString}; kwargs...)
+  return GradingType(first(s); kwargs..., name=last(s))
 end
-function SymmetryType(s::Pair{<:AbstractString,<:NamedTuple}; kwargs...)
-  return SymmetryType(first(s); kwargs..., last(s)...)
+function GradingType(s::Pair{<:AbstractString,<:NamedTuple}; kwargs...)
+  return GradingType(first(s); kwargs..., last(s)...)
 end
-macro SymmetryType_str(s)
-  return :(SymmetryType{$(Expr(:quote, Symbol(s)))})
+macro GradingType_str(s)
+  return :(GradingType{$(Expr(:quote, Symbol(s)))})
 end
 
-function Base.AbstractUnitRange(symmetry::SymmetryType, t::SiteType)
+function Base.AbstractUnitRange(grading::GradingType, t::SiteType)
   return error("Not implemented.")
 end
-function Base.AbstractUnitRange(symmetry::SymmetryType"Trivial", t::SiteType)
+function Base.AbstractUnitRange(grading::GradingType"Trivial", t::SiteType)
   return Base.OneTo(length(t))
 end
 
@@ -70,8 +70,8 @@ function Base.AbstractUnitRange(t::SiteType)
   # This logic allows specifying a range with extra properties,
   # like ones with symmetry sectors.
   haskey(t, :range) && return t.range
-  if haskey(t, :symmetries)
-    rs = map(symmetry -> AbstractUnitRange(SymmetryType(symmetry), t), t.symmetries)
+  if haskey(t, :gradings)
+    rs = map(grading -> AbstractUnitRange(GradingType(grading), t), t.gradings)
     return combine_axes(Base.OneTo(length(t)), rs...)
   end
   return Base.OneTo(length(t))

--- a/src/sitetype.jl
+++ b/src/sitetype.jl
@@ -66,6 +66,9 @@ function Base.length(t::SiteType)
   end
   return length(t′)
 end
+# TODO: Use a shorthand `(t::SiteType)() = AbstractUnitRange(t)`,
+# i.e. make `SiteType` callable like `OpName` and `StateName`
+# are right now.
 function Base.AbstractUnitRange(t::SiteType)
   # This logic allows specifying a range with extra properties,
   # like ones with symmetry sectors.
@@ -75,6 +78,10 @@ function Base.AbstractUnitRange(t::SiteType)
     return combine_axes(Base.OneTo(length(t)), rs...)
   end
   return Base.OneTo(length(t))
+end
+# kwargs are passed for fancier constructors, like `ITensors.Index`.
+function (rangetype::Type{<:AbstractUnitRange})(t::SiteType; kwargs...)
+  return rangetype(AbstractUnitRange(t); kwargs...)
 end
 Base.size(t::SiteType) = (length(t),)
 Base.size(t::SiteType, dim::Integer) = size(t)[dim]

--- a/src/sitetype.jl
+++ b/src/sitetype.jl
@@ -4,14 +4,15 @@ struct SiteType{T,Params}
     return new{N,typeof(params)}(params)
   end
 end
+value(::SiteType{T}) where {T} = T
 params(t::SiteType) = getfield(t, :params)
 Base.getproperty(t::SiteType, name::Symbol) = getfield(params(t), name)
+Base.get(t::SiteType, name::Symbol, default) = get(params(t), name, default)
 
 SiteType{N}(; kwargs...) where {N} = SiteType{N}((; kwargs...))
 
 SiteType(s::AbstractString; kwargs...) = SiteType{Symbol(s)}(; kwargs...)
 SiteType(i::Integer; kwargs...) = SiteType{Symbol(i)}(; kwargs...)
-value(::SiteType{T}) where {T} = T
 macro SiteType_str(s)
   return SiteType{Symbol(s)}
 end
@@ -26,7 +27,11 @@ function Base.length(t::SiteType)
   end
   return length(t′)
 end
-Base.AbstractUnitRange(t::SiteType) = Base.OneTo(length(t))
+function Base.AbstractUnitRange(t::SiteType)
+  # This logic allows specifying a range with extra properties,
+  # like ones with symmetry sectors.
+  return get(t, :range, Base.OneTo(length(t)))
+end
 Base.size(t::SiteType) = (length(t),)
 Base.size(t::SiteType, dim::Integer) = size(t)[dim]
 Base.axes(t::SiteType) = (AbstractUnitRange(t),)

--- a/src/sitetype.jl
+++ b/src/sitetype.jl
@@ -80,8 +80,8 @@ function Base.AbstractUnitRange(t::SiteType)
   return Base.OneTo(length(t))
 end
 # kwargs are passed for fancier constructors, like `ITensors.Index`.
-function (rangetype::Type{<:AbstractUnitRange})(t::SiteType; kwargs...)
-  return rangetype(AbstractUnitRange(t); kwargs...)
+function (rangetype::Type{<:AbstractUnitRange})(t::SiteType)
+  return rangetype(AbstractUnitRange(t))
 end
 Base.size(t::SiteType) = (length(t),)
 Base.size(t::SiteType, dim::Integer) = size(t)[dim]

--- a/src/state.jl
+++ b/src/state.jl
@@ -32,10 +32,6 @@ macro state_alias(name1, name2, params...)
   return state_alias_expr(name1, name2)
 end
 
-function Base.axes(::StateName, domain::Tuple{Vararg{AbstractUnitRange}})
-  return domain
-end
-
 # This compiles operator expressions, such as:
 # ```julia
 # stateexpr("0 + 1") == StateName("0") + StateName("1")
@@ -118,6 +114,15 @@ function state_or_op_expr(ntype::Type, ex::Expr, depth::Int)
     return ntype{ex.args[1]}(; kwargs...)
   end
   return error("Can't parse expression $ex.")
+end
+
+function Base.axes(::StateName, domain::Tuple{Vararg{AbstractUnitRange}})
+  return domain
+end
+
+function reverse_sites(n::StateName, a::AbstractArray)
+  perm = reverse(ntuple(identity, ndims(a)))
+  return permutedims(a, perm)
 end
 
 function state(arrtype::Type{<:AbstractArray}, n::Union{Int,String}, domain...; kwargs...)

--- a/src/state.jl
+++ b/src/state.jl
@@ -32,15 +32,8 @@ macro state_alias(name1, name2, params...)
   return state_alias_expr(name1, name2)
 end
 
-function (arrtype::Type{<:AbstractArray})(n::StateName, domain::Tuple{Vararg{SiteType}})
-  # TODO: Define `state_convert` to handle reshaping multisite states
-  # to higher order arrays.
-  return convert(arrtype, n(domain...))
-end
-function (arrtype::Type{<:AbstractArray})(n::StateName, domain::Tuple{Vararg{Integer}})
-  # TODO: Define `state_convert` to handle reshaping multisite states
-  # to higher order arrays.
-  return convert(arrtype, n(Int.(domain)...))
+function state_or_op_axes(::StateName, domain::Tuple{Vararg{AbstractUnitRange}})
+  return domain
 end
 
 # This compiles operator expressions, such as:

--- a/src/state.jl
+++ b/src/state.jl
@@ -32,7 +32,7 @@ macro state_alias(name1, name2, params...)
   return state_alias_expr(name1, name2)
 end
 
-function state_or_op_axes(::StateName, domain::Tuple{Vararg{AbstractUnitRange}})
+function Base.axes(::StateName, domain::Tuple{Vararg{AbstractUnitRange}})
   return domain
 end
 

--- a/src/state.jl
+++ b/src/state.jl
@@ -6,14 +6,15 @@ struct StateName{Name,Params}
     return new{N,typeof(params)}(params)
   end
 end
+name(::StateName{N}) where {N} = N
 params(n::StateName) = getfield(n, :params)
 Base.getproperty(n::StateName, name::Symbol) = getfield(params(n), name)
+Base.get(t::StateName, name::Symbol, default) = get(params(t), name, default)
 
 StateName{N}(; kwargs...) where {N} = StateName{N}((; kwargs...))
 
 StateName(s::AbstractString; kwargs...) = StateName{Symbol(s)}(; kwargs...)
 StateName(s::Symbol; kwargs...) = StateName{s}(; kwargs...)
-name(::StateName{N}) where {N} = N
 macro StateName_str(s)
   return StateName{Symbol(s)}
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 BlockSparseArrays = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 ITensorBase = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,11 +1,15 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BlockSparseArrays = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
+GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
 ITensorBase = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 QuantumOperatorDefinitions = "826dd319-6fd5-459a-a990-3a4f214664bf"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+SymmetrySectors = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -33,22 +33,30 @@ const elts = (real_elts..., complex_elts...)
         [0 -im; im 0],
         [1 0; 0 -1],
         [0 0; 0 1],
-        [1 0 0 0; 0 0 1 0; 0 1 0 0; 0 0 0 1],
-        [1 0 0 0; 0 0 im 0; 0 im 0 0; 0 0 0 1],
-        (_, θ) -> [
-          cos(θ / 2) 0 0 -im*sin(θ / 2)
-          0 cos(θ / 2) -im*sin(θ / 2) 0
-          0 -im*sin(θ / 2) cos(θ / 2) 0
-          -im*sin(θ / 2) 0 0 cos(θ / 2)
-        ],
-        (_, θ) -> [
-          cos(θ / 2) 0 0 im*sin(θ / 2)
-          0 cos(θ / 2) -im*sin(θ / 2) 0
-          0 -im*sin(θ / 2) cos(θ / 2) 0
-          im*sin(θ / 2) 0 0 cos(θ / 2)
-        ],
-        (_, θ) ->
+        reshape([1 0 0 0; 0 0 1 0; 0 1 0 0; 0 0 0 1], (2, 2, 2, 2)),
+        reshape([1 0 0 0; 0 0 im 0; 0 im 0 0; 0 0 0 1], (2, 2, 2, 2)),
+        (_, θ) -> reshape(
+          [
+            cos(θ / 2) 0 0 -im*sin(θ / 2)
+            0 cos(θ / 2) -im*sin(θ / 2) 0
+            0 -im*sin(θ / 2) cos(θ / 2) 0
+            -im*sin(θ / 2) 0 0 cos(θ / 2)
+          ],
+          (2, 2, 2, 2),
+        ),
+        (_, θ) -> reshape(
+          [
+            cos(θ / 2) 0 0 im*sin(θ / 2)
+            0 cos(θ / 2) -im*sin(θ / 2) 0
+            0 -im*sin(θ / 2) cos(θ / 2) 0
+            im*sin(θ / 2) 0 0 cos(θ / 2)
+          ],
+          (2, 2, 2, 2),
+        ),
+        (_, θ) -> reshape(
           Diagonal([exp(-im * θ / 2), exp(im * θ / 2), exp(im * θ / 2), exp(-im * θ / 2)]),
+          (2, 2, 2, 2),
+        ),
         [1 0; 0 0],
         [0 0; 0 1],
         [0 1; 0 0],
@@ -60,31 +68,37 @@ const elts = (real_elts..., complex_elts...)
         √2 * [0 -im 0; im 0 -im; 0 im 0],
         2 * [1 0 0; 0 0 0; 0 0 -1],
         [0 0 0; 0 1 0; 0 0 2],
-        [
-          1 0 0 0 0 0 0 0 0
-          0 0 0 1 0 0 0 0 0
-          0 0 0 0 0 0 1 0 0
-          0 1 0 0 0 0 0 0 0
-          0 0 0 0 1 0 0 0 0
-          0 0 0 0 0 0 0 1 0
-          0 0 1 0 0 0 0 0 0
-          0 0 0 0 0 1 0 0 0
-          0 0 0 0 0 0 0 0 1
-        ],
-        [
-          1 0 0 0 0 0 0 0 0
-          0 0 0 im 0 0 0 0 0
-          0 0 0 0 0 0 im 0 0
-          0 im 0 0 0 0 0 0 0
-          0 0 0 0 1 0 0 0 0
-          0 0 0 0 0 0 0 im 0
-          0 0 im 0 0 0 0 0 0
-          0 0 0 0 0 im 0 0 0
-          0 0 0 0 0 0 0 0 1
-        ],
-        (O, θ) -> exp(-im * (θ / 2) * kron(O, O)),
-        (O, θ) -> exp(-im * (θ / 2) * kron(O, O)),
-        (O, θ) -> exp(-im * (θ / 2) * kron(O, O)),
+        reshape(
+          [
+            1 0 0 0 0 0 0 0 0
+            0 0 0 1 0 0 0 0 0
+            0 0 0 0 0 0 1 0 0
+            0 1 0 0 0 0 0 0 0
+            0 0 0 0 1 0 0 0 0
+            0 0 0 0 0 0 0 1 0
+            0 0 1 0 0 0 0 0 0
+            0 0 0 0 0 1 0 0 0
+            0 0 0 0 0 0 0 0 1
+          ],
+          (3, 3, 3, 3),
+        ),
+        reshape(
+          [
+            1 0 0 0 0 0 0 0 0
+            0 0 0 im 0 0 0 0 0
+            0 0 0 0 0 0 im 0 0
+            0 im 0 0 0 0 0 0 0
+            0 0 0 0 1 0 0 0 0
+            0 0 0 0 0 0 0 im 0
+            0 0 im 0 0 0 0 0 0
+            0 0 0 0 0 im 0 0 0
+            0 0 0 0 0 0 0 0 1
+          ],
+          (3, 3, 3, 3),
+        ),
+        (O, θ) -> reshape(exp(-im * (θ / 2) * kron(O, O)), (3, 3, 3, 3)),
+        (O, θ) -> reshape(exp(-im * (θ / 2) * kron(O, O)), (3, 3, 3, 3)),
+        (O, θ) -> reshape(exp(-im * (θ / 2) * kron(O, O)), (3, 3, 3, 3)),
         [1 0 0; 0 0 0; 0 0 0],
         [0 0 0; 0 1 0; 0 0 0],
         [0 1 0; 0 0 0; 0 0 0],
@@ -114,9 +128,9 @@ const elts = (real_elts..., complex_elts...)
         (OpName("Ry"; θ=π / 3), 1, complex_elts, exp(-im * π / 6 * Ymat)),
         (OpName("Rz"; θ=π / 3), 1, complex_elts, exp(-im * π / 6 * Zmat)),
         (OpName("SWAP"), 2, elts, SWAPmat),
-        (OpName("√SWAP"), 2, complex_elts, √SWAPmat),
+        # (OpName("√SWAP"), 2, complex_elts, √SWAPmat),
         (OpName("iSWAP"), 2, complex_elts, iSWAPmat),
-        (OpName("√iSWAP"), 2, complex_elts, √iSWAPmat),
+        # (OpName("√iSWAP"), 2, complex_elts, √iSWAPmat),
         (OpName("Rxx"; θ=π / 3), 2, complex_elts, RXXmat(Xmat, π / 3)),
         (OpName("RXX"; θ=π / 3), 2, complex_elts, RXXmat(Xmat, π / 3)),
         (OpName("Ryy"; θ=π / 3), 2, complex_elts, RYYmat(Ymat, π / 3)),
@@ -128,7 +142,7 @@ const elts = (real_elts..., complex_elts...)
         (OpName("StandardBasis"; index=(1, 2)), 1, elts, StandardBasis12mat),
       )
         @test nsites(o) == nbits
-        for arraytype in (AbstractArray, AbstractMatrix, Array, Matrix)
+        for arraytype in (AbstractArray, Array)
           for elt in elts
             ts = ntuple(Returns(t), nbits)
             lens = ntuple(Returns(len), nbits)
@@ -149,7 +163,7 @@ const elts = (real_elts..., complex_elts...)
     @test op("X * Y + 2 * Z") == op("X") * op("Y") + 2 * op("Z")
     @test op("exp(im * (X * Y + 2 * Z))") == exp(im * (op("X") * op("Y") + 2 * op("Z")))
     @test op("exp(im * (X ⊗ Y + Z ⊗ Z))") ==
-      exp(im * (kron(op("X"), op("Y")) + kron(op("Z"), op("Z"))))
+      reshape(exp(im * (kron(op("X"), op("Y")) + kron(op("Z"), op("Z")))), (2, 2, 2, 2))
     @test op("Ry{θ=π/2}") == op("Ry"; θ=π / 2)
     # Awkward parsing corner cases.
     @test op("S+") == Matrix(OpName("S+"))
@@ -187,7 +201,7 @@ const elts = (real_elts..., complex_elts...)
     @test state("2", 3) == [0, 0, 1]
 
     @test state("|0⟩ + 2|+⟩") == state("0") + 2 * state("+")
-    @test state("|0⟩ ⊗ |+⟩") == kron(state("0"), state("+"))
+    @test state("|0⟩ ⊗ |+⟩") == reshape(kron(state("0"), state("+")), (2, 2))
   end
   @testset "Electron/tJ" begin
     for (ns, x) in (

--- a/test/test_itensorbaseext.jl
+++ b/test/test_itensorbaseext.jl
@@ -1,13 +1,64 @@
-using ITensorBase: ITensor, Index, prime
-using QuantumOperatorDefinitions: op, state
-using Test: @test, @testset
+using ITensorBase: ITensor, Index, gettag, prime, settag
+using QuantumOperatorDefinitions: OpName, SiteType, StateName, op, state
+using Test: @test, @test_broken, @testset
 
-@testset "QuantumOperatorDefinitionsITensorBaseExt" begin
+@testset "ITensorBaseExt" begin
+  i = Index(SiteType("S=1/2"))
+  @test gettag(i, "sitetype") == "S=1/2"
+
   i = Index(2)
+  a = state("0", i)
+  @test a == ITensor(state("0", 2), i)
+  @test a == state("0", (i,))
+  @test a == ITensor(StateName("0"), i)
+  @test a == ITensor(StateName("0"), (i,))
 
+  i = settag(Index(2), "sitetype", "S=1/2")
+  a = state("X+", i)
+  @test a == ITensor(state("X+", SiteType("S=1/2")), i)
+
+  i = Index(2)
   a = op("X", i)
-  @test a == ITensor([0 1; 1 0], (prime(i), i))
+  @test a == ITensor(op("X", 2), (prime(i), i))
+  @test a == op("X", (i,))
+  @test a == ITensor(OpName("X"), i)
+  @test a == ITensor(OpName("X"), (i,))
 
-  a = state(1, i)
-  @test a == ITensor([1, 0], (i,))
+  i1 = Index(2)
+  i2 = Index(2)
+  i1′ = prime(i1)
+  i2′ = prime(i2)
+  a = ITensor(OpName("CX"), (i1, i2))
+  @test a == ITensor(op("CX", (2, 2)), (i1′, i2′, i1, i2))
+  @test a[i1′[1], i2′, i1[1], i2] == op("I", i2)
+  @test a[i1′[2], i2′, i1[1], i2] == zeros(i2′, i2)
+  @test a[i1′[1], i2′, i1[2], i2] == zeros(i2′, i2)
+  @test a[i1′[2], i2′, i1[2], i2] == op("X", i2)
+
+  i1 = Index(3)
+  i2 = Index(2)
+  i1′ = prime(i1)
+  i2′ = prime(i2)
+  a = ITensor(OpName("CX"), (i1, i2))
+  @test a == ITensor(op("CX", (3, 2)), (i1′, i2′, i1, i2))
+  @test a[i1′[1], i2′, i1[1], i2] == op("I", i2)
+  @test a[i1′[2], i2′, i1[1], i2] == zeros(i2′, i2)
+  @test a[i1′[3], i2′, i1[1], i2] == zeros(i2′, i2)
+  @test a[i1′[1], i2′, i1[2], i2] == zeros(i2′, i2)
+  @test a[i1′[2], i2′, i1[2], i2] == op("I", i2)
+  @test a[i1′[3], i2′, i1[2], i2] == zeros(i2′, i2)
+  @test a[i1′[1], i2′, i1[3], i2] == zeros(i2′, i2)
+  @test a[i1′[2], i2′, i1[3], i2] == zeros(i2′, i2)
+  @test a[i1′[3], i2′, i1[3], i2] == op("X", i2)
+
+  i1 = Index(2)
+  i2 = Index(3)
+  i1′ = prime(i1)
+  i2′ = prime(i2)
+  a = ITensor(OpName("CX"), (i1, i2))
+  @test a == ITensor(op("CX", (2, 3)), (i1′, i2′, i1, i2))
+  @test a[i1′[1], i2′, i1[1], i2] == op("I", i2)
+  @test a[i1′[2], i2′, i1[1], i2] == zeros(i2′, i2)
+  @test a[i1′[1], i2′, i1[2], i2] == zeros(i2′, i2)
+  @test a[i1′[2], i2′, i1[2], i2] == op("X", i2)
 end

--- a/test/test_itensorbaseext.jl
+++ b/test/test_itensorbaseext.jl
@@ -1,6 +1,6 @@
 using ITensorBase: ITensor, Index, gettag, prime, settag
 using QuantumOperatorDefinitions: OpName, SiteType, StateName, op, state
-using Test: @test, @test_broken, @testset
+using Test: @test, @testset
 
 @testset "ITensorBaseExt" begin
   i = Index(SiteType("S=1/2"))

--- a/test/test_symmetrysectorsext.jl
+++ b/test/test_symmetrysectorsext.jl
@@ -54,10 +54,10 @@ using Test: @test, @test_broken, @testset
   @test blocklabels(r2) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
   @test blocklengths(r2) == [1, 1]
 
-  # TODO: There is a bug slicing `BitVector` by `GradedOneTo`, investigate.
-  # See: https://github.com/ITensor/GradedUnitRanges.jl/issues/9
+  # TODO: There is a bug slicing `BitVector` by `GradedOneTo` in Julia 1.11,
+  # investigate. See: https://github.com/ITensor/GradedUnitRanges.jl/issues/9
   t = SiteType("S=1/2"; gradings=("Sz",))
-  @test_broken state("0", t)
+  @test state("0", t) == [1, 0] broken = VERSION ≥ v"1.11"
 
   # Force conversion to `Vector{Float64}` before conversion,
   # since there is a bug slicing `BitVector` by `GradedOneTo`.

--- a/test/test_symmetrysectorsext.jl
+++ b/test/test_symmetrysectorsext.jl
@@ -1,0 +1,113 @@
+using BlockArrays: AbstractBlockArray, blocklengths
+using BlockSparseArrays: BlockSparseArray
+using GradedUnitRanges: blocklabels
+using ITensorBase: ITensor, Index, gettag, prime, settag
+using QuantumOperatorDefinitions: OpName, SiteType, StateName, op, state
+using SymmetrySectors: SectorProduct, U1, Z
+using NamedDimsArrays: dename
+using Test: @test, @test_broken, @testset
+
+@testset "SymmetrySectorsExt" begin
+  t = SiteType("S=1/2"; gradings=("Sz",))
+  r = AbstractUnitRange(t)
+  @test r == 1:2
+  @test blocklabels(r) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(1)))]
+  @test blocklengths(r) == [1, 1]
+
+  t = SiteType("Electron"; gradings=("Nf", "Sz"))
+  r = AbstractUnitRange(t)
+  @test r == 1:4
+  @test blocklabels(r) == [
+    SectorProduct((; Nf=U1(0), Sz=U1(0))),
+    SectorProduct((; Nf=U1(1), Sz=U1(1))),
+    SectorProduct((; Nf=U1(1), Sz=U1(-1))),
+    SectorProduct((; Nf=U1(2), Sz=U1(0))),
+  ]
+  @test blocklengths(r) == [1, 1, 1, 1]
+
+  t = SiteType("Electron"; gradings=("Nf" => "NfA", "Sz" => "SzA"))
+  r = AbstractUnitRange(t)
+  @test r == 1:4
+  @test blocklabels(r) == [
+    SectorProduct((; NfA=U1(0), SzA=U1(0))),
+    SectorProduct((; NfA=U1(1), SzA=U1(1))),
+    SectorProduct((; NfA=U1(1), SzA=U1(-1))),
+    SectorProduct((; NfA=U1(2), SzA=U1(0))),
+  ]
+  @test blocklengths(r) == [1, 1, 1, 1]
+
+  t = SiteType("Electron"; gradings=("NfParity", "Sz"))
+  r = AbstractUnitRange(t)
+  @test r == 1:4
+  @test blocklabels(r) == [
+    SectorProduct((; NfParity=Z{2}(0), Sz=U1(0))),
+    SectorProduct((; NfParity=Z{2}(1), Sz=U1(1))),
+    SectorProduct((; NfParity=Z{2}(1), Sz=U1(-1))),
+    SectorProduct((; NfParity=Z{2}(0), Sz=U1(0))),
+  ]
+  @test blocklengths(r) == [1, 1, 1, 1]
+
+  t = SiteType("S=1/2"; gradings=("Sz",))
+  (r1, r2) = axes(OpName("σ⁺"), (t,))
+  @test blocklabels(r1) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(1)))]
+  @test blocklengths(r1) == [1, 1]
+  @test blocklabels(r2) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
+  @test blocklengths(r2) == [1, 1]
+
+  # TODO: There is a bug slicing `BitVector` by `GradedOneTo`, investigate.
+  # See: https://github.com/ITensor/GradedUnitRanges.jl/issues/9
+  t = SiteType("S=1/2"; gradings=("Sz",))
+  @test_broken state("0", t)
+
+  # Force conversion to `Vector{Float64}` before conversion,
+  # since there is a bug slicing `BitVector` by `GradedOneTo`.
+  t = SiteType("S=1/2"; gradings=("Sz",))
+  a = AbstractArray(2.0 * StateName("0"), t)
+  @test a == [2, 0]
+  @test a isa AbstractBlockArray
+  # TODO: Currently slicing a dense array by graded ranges outputs a `BlockedArray`
+  # rather than a `BlockSparseArray`.
+  # See: https://github.com/ITensor/GradedUnitRanges.jl/issues/9
+  @test_broken a isa BlockSparseArray
+  (r1,) = axes(a)
+  @test blocklabels(r1) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(1)))]
+  @test blocklengths(r1) == [1, 1]
+
+  t = SiteType("S=1/2"; gradings=("Sz",))
+  a = op("σ⁺", t)
+  @test a == [0 2; 0 0]
+  @test a isa AbstractBlockArray
+  @test_broken a isa BlockSparseArray
+  (r1, r2) = axes(a)
+  @test blocklabels(r1) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(1)))]
+  @test blocklengths(r1) == [1, 1]
+  # TODO: This is a bug in indexing with GradedUnitRangeDual, fix this.
+  @test_broken blocklabels(r2) ==
+    [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
+  @test blocklengths(r2) == [1, 1]
+end
+
+@testset "SymmetrySectorsExt + ITensorBaseExt" begin
+  i = Index(SiteType("S=1/2"; gradings=("Sz",)))
+  @test gettag(i, "sitetype") == "S=1/2"
+  # TODO: Test without denaming.
+  @test dename(i) == 1:2
+  @test blocklabels(dename(i)) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(1)))]
+  @test blocklengths(dename(i)) == [1, 1]
+
+  i′ = prime(i)
+  a = op("σ⁺", i)
+  # TODO: The indices should be `(i′, dual(i))`.
+  @test a == ITensor([0 2; 0 0], (i′, i))
+  a′ = dename(a)
+  @test a′ isa AbstractBlockArray
+  @test_broken a′ isa BlockSparseArray
+  # TODO: Test these without denaming `a`.
+  (r1, r2) = axes(a′)
+  @test blocklabels(r1) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(1)))]
+  @test blocklengths(r1) == [1, 1]
+  # TODO: This is a bug in indexing with GradedUnitRangeDual, fix this.
+  @test_broken blocklabels(r2) ==
+    [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
+  @test blocklengths(r2) == [1, 1]
+end


### PR DESCRIPTION
This enables passing custom axes when constructing operators.

It also adds an ITensor extension for constructing ITensors when Index objects are passed as the axes.

This also adds an interface for specifying and customizing symmetries of axes/Index objects, similar to this old proposal: https://github.com/ITensor/ITensors.jl/issues/522.

To-do:
- [x] Add tests.
- [x] Try to make `Index(::SiteType)` "just work" through a generic function `(rangetype::Type{<:AbstractUnitRange}; kwargs...)(t::SiteType) = rangetype(AbstractUnitRange(t); kwargs...)`.
- [x] Decide if multi-site operators like `op("SWAP")` should output n-dimensional arrays or matrices, this PR changes the behavior so that it reshapes to n-dimensional arrays, which is a bit annoying for dense arrays but makes sense for block sparse/symmetric tensors since reshaping is much less trivial in those cases.
- [x] Look into how things work constructing ITensors for multi-site operators. Does the memory ordering match what is expected? The site indices may be reverse of what we want, since it is based on Julia's memory ordering convention.

Open to track elsewhere and fix in followup PRs: 
- [x] Fix `"SWAP"` gates so that sites of the output get swapped properly. The current code is correct if the sites are exactly the same, but with named dimensions and site of different sizes the code isn't correct. (Tracking in #20.)
- [x] Consider making `SiteType` callable, similar to `OpName` and `StateName`, so that `SiteType("S=1/2")()` constructs the unit range `AbstractUnitRange(SiteType("S=1/2"))`. (Tracking in #18.)
- [x] `Diagonal` operators are getting converted to dense with the current code design. (Tracking in #19.)
- [x] Constructing single-site states is hitting a bug in NamedDimsArrays since `randn(2)[Index(2)]` hits an ambiguity error. (Tracking in https://github.com/ITensor/ITensorBase.jl/issues/25.)
- [x] When the axes are graded, currently the code constructs block dense arrays rather than block sparse arrays. We'll want to special `getindex(::AbstractArray, ::AbstractGradedUnitRange...)`. (Tracking in https://github.com/ITensor/GradedUnitRanges.jl/issues/9.)
- [x] `randn(2, 2)[r, dual(r)]` where `r isa AbstractGradedUnitRange` drops the dual information. (Tracking in https://github.com/ITensor/GradedUnitRanges.jl/issues/9.)
- [x] There is an issue converting `BitArray`s to block arrays and ITensors when the axes are graded (probably will be fixed when the above issue is fixed). (Tracking in https://github.com/ITensor/GradedUnitRanges.jl/issues/9.)
