### PR TITLE
Use `dual` to take the dual of the domain when building symmetric operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumOperatorDefinitions"
 uuid = "826dd319-6fd5-459a-a990-3a4f214664bf"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -10,13 +10,13 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [weakdeps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 GradedUnitRanges = "e2de450a-8a67-46c7-b59c-01d5a3d041c5"
-LabelledNumbers = "f856a3a6-4152-4ec4-b2a7-02c1a55d7993"
 ITensorBase = "4795dd04-0d67-49bb-8f44-b89c448a1dc7"
+LabelledNumbers = "f856a3a6-4152-4ec4-b2a7-02c1a55d7993"
 NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 SymmetrySectors = "f8a8ad64-adbc-4fce-92f7-ffe2bb36a86e"
 
 [extensions]
-QuantumOperatorDefinitionsITensorBaseExt = ["ITensorBase", "NamedDimsArrays"]
+QuantumOperatorDefinitionsITensorBaseExt = ["ITensorBase", "GradedUnitRanges", "NamedDimsArrays"]
 QuantumOperatorDefinitionsSymmetrySectorsExt = ["BlockArrays", "GradedUnitRanges", "LabelledNumbers", "SymmetrySectors"]
 
 [compat]

--- a/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
+++ b/ext/QuantumOperatorDefinitionsITensorBaseExt/QuantumOperatorDefinitionsITensorBaseExt.jl
@@ -1,6 +1,7 @@
 module QuantumOperatorDefinitionsITensorBaseExt
 
-using ITensorBase: ITensorBase, ITensor, Index, dag, gettag, prime, settag
+using ITensorBase: ITensorBase, ITensor, Index, gettag, prime, settag
+using GradedUnitRanges: dual
 using NamedDimsArrays: dename
 using QuantumOperatorDefinitions:
   QuantumOperatorDefinitions,
@@ -38,7 +39,7 @@ function QuantumOperatorDefinitions.has_fermion_string(n::String, r::Index)
 end
 
 function Base.axes(::OpName, domain::Tuple{Vararg{Index}})
-  return (prime.(domain)..., dag.(domain)...)
+  return (prime.(domain)..., dual.(domain)...)
 end
 ## function Base.axes(::OpName"SWAP", domain::Tuple{Vararg{Index}})
 ##   return (prime.(reverse(domain))..., dag.(domain)...)

--- a/src/sitetype.jl
+++ b/src/sitetype.jl
@@ -79,7 +79,6 @@ function Base.AbstractUnitRange(t::SiteType)
   end
   return Base.OneTo(length(t))
 end
-# kwargs are passed for fancier constructors, like `ITensors.Index`.
 function (rangetype::Type{<:AbstractUnitRange})(t::SiteType)
   return rangetype(AbstractUnitRange(t))
 end

--- a/test/test_itensorbaseext.jl
+++ b/test/test_itensorbaseext.jl
@@ -1,3 +1,4 @@
+using GradedUnitRanges: GradedUnitRanges
 using ITensorBase: ITensor, Index, gettag, hastag, prime, settag
 using NamedDimsArrays: dename
 using QuantumOperatorDefinitions: OpName, SiteType, StateName, op, site, sites, state

--- a/test/test_symmetrysectorsext.jl
+++ b/test/test_symmetrysectorsext.jl
@@ -5,7 +5,7 @@ using ITensorBase: ITensor, Index, gettag, prime, settag
 using QuantumOperatorDefinitions: OpName, SiteType, StateName, op, state
 using SymmetrySectors: SectorProduct, U1, Z
 using NamedDimsArrays: dename
-using Test: @test, @test_broken, @testset
+using Test: @test, @testset
 
 @testset "SymmetrySectorsExt" begin
   t = SiteType("S=1/2"; gradings=("Sz",))
@@ -54,10 +54,8 @@ using Test: @test, @test_broken, @testset
   @test blocklabels(r2) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
   @test blocklengths(r2) == [1, 1]
 
-  # TODO: There is a bug slicing `BitVector` by `GradedOneTo` in Julia 1.11,
-  # investigate. See: https://github.com/ITensor/GradedUnitRanges.jl/issues/9
   t = SiteType("S=1/2"; gradings=("Sz",))
-  @test state("0", t) == [1, 0] broken = VERSION ≥ v"1.11"
+  @test state("0", t) == [1, 0]
 
   # Force conversion to `Vector{Float64}` before conversion,
   # since there is a bug slicing `BitVector` by `GradedOneTo`.

--- a/test/test_symmetrysectorsext.jl
+++ b/test/test_symmetrysectorsext.jl
@@ -76,8 +76,7 @@ using Test: @test, @test_broken, @testset
   (r1, r2) = axes(a)
   @test blocklabels(r1) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(1)))]
   @test blocklengths(r1) == [1, 1]
-  @test blocklabels(r2) ==
-    [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
+  @test blocklabels(r2) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
   @test blocklengths(r2) == [1, 1]
 end
 
@@ -99,7 +98,6 @@ end
   (r1, r2) = axes(a′)
   @test blocklabels(r1) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(1)))]
   @test blocklengths(r1) == [1, 1]
-  @test blocklabels(r2) ==
-    [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
+  @test blocklabels(r2) == [SectorProduct((; Sz=U1(0))), SectorProduct((; Sz=U1(-1)))]
   @test blocklengths(r2) == [1, 1]
 end


### PR DESCRIPTION
In combination with https://github.com/ITensor/NamedDimsArrays.jl/pull/33, this makes sure the domain of the operator is properly dualed.

Todo:
- [x] Add tests.